### PR TITLE
feat: update chai to latest, add type field in pkgjson

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1,7 +1,11 @@
-var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
 function commonjsRequire () {
 	throw new Error('Dynamic requires are not currently supported by rollup-plugin-commonjs');
+}
+
+function unwrapExports (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
 function createCommonjsModule(fn, module) {
@@ -25,7 +29,7 @@ var used = [];
  * Chai version
  */
 
-exports.version = '4.2.0';
+exports.version = '4.3.3';
 
 /*!
  * Assertion Error
@@ -247,11 +251,21 @@ module.exports = function (_chai, util) {
     if (!ok) {
       msg = util.getMessage(this, arguments);
       var actual = util.getActual(this, arguments);
-      throw new AssertionError(msg, {
+      var assertionErrorObjectProperties = {
           actual: actual
         , expected: expected
         , showDiff: showDiff
-      }, (config.includeStack) ? this.assert : flag(this, 'ssfi'));
+      };
+
+      var operator = util.getOperator(this, arguments);
+      if (operator) {
+        assertionErrorObjectProperties.operator = operator;
+      }
+
+      throw new AssertionError(
+        msg,
+        assertionErrorObjectProperties,
+        (config.includeStack) ? this.assert : flag(this, 'ssfi'));
     }
   };
 
@@ -406,6 +420,7 @@ module.exports = function (chai, _) {
    * - but
    * - does
    * - still
+   * - also
    *
    * @name language chains
    * @namespace BDD
@@ -415,7 +430,7 @@ module.exports = function (chai, _) {
   [ 'to', 'be', 'been', 'is'
   , 'and', 'has', 'have', 'with'
   , 'that', 'which', 'at', 'of'
-  , 'same', 'but', 'does', 'still' ].forEach(function (chain) {
+  , 'same', 'but', 'does', 'still', "also" ].forEach(function (chain) {
     Assertion.addProperty(chain);
   });
 
@@ -905,8 +920,13 @@ module.exports = function (chai, _) {
         // objects with a custom `@@toStringTag`.
         if (val !== Object(val)) {
           throw new AssertionError(
-            flagMsg + 'object tested must be an array, a map, an object,'
-              + ' a set, a string, or a weakset, but ' + objType + ' given',
+            flagMsg + 'the given combination of arguments ('
+            + objType + ' and '
+            + _.type(val).toLowerCase() + ')'
+            + ' is invalid for this assertion. '
+            + 'You can use an array, a map, an object, a set, a string, '
+            + 'or a weakset instead of a '
+            + _.type(val).toLowerCase(),
             undefined,
             ssfi
           );
@@ -1190,19 +1210,25 @@ module.exports = function (chai, _) {
    *
    *     expect(null, 'nooo why fail??').to.exist;
    *
+   * The alias `.exists` can be used interchangeably with `.exist`.
+   *
    * @name exist
+   * @alias exists
    * @namespace BDD
    * @api public
    */
 
-  Assertion.addProperty('exist', function () {
+  function assertExist () {
     var val = flag(this, 'object');
     this.assert(
         val !== null && val !== undefined
       , 'expected #{this} to exist'
       , 'expected #{this} to not exist'
     );
-  });
+  }
+
+  Assertion.addProperty('exist', assertExist);
+  Assertion.addProperty('exists', assertExist);
 
   /**
    * ### .empty
@@ -1311,7 +1337,7 @@ module.exports = function (chai, _) {
    *
    * Add `.not` earlier in the chain to negate `.arguments`. However, it's often
    * best to assert which type the target is expected to be, rather than
-   * asserting that its not an `arguments` object.
+   * asserting that it’s not an `arguments` object.
    *
    *     expect('foo').to.be.a('string'); // Recommended
    *     expect('foo').to.not.be.arguments; // Not recommended
@@ -1602,10 +1628,12 @@ module.exports = function (chai, _) {
    *     expect(1).to.be.at.least(2, 'nooo why fail??');
    *     expect(1, 'nooo why fail??').to.be.at.least(2);
    *
-   * The alias `.gte` can be used interchangeably with `.least`.
+   * The aliases `.gte` and `.greaterThanOrEqual` can be used interchangeably with
+   * `.least`.
    *
    * @name least
    * @alias gte
+   * @alias greaterThanOrEqual
    * @param {Number} n
    * @param {String} msg _optional_
    * @namespace BDD
@@ -1671,6 +1699,7 @@ module.exports = function (chai, _) {
 
   Assertion.addMethod('least', assertLeast);
   Assertion.addMethod('gte', assertLeast);
+  Assertion.addMethod('greaterThanOrEqual', assertLeast);
 
   /**
    * ### .below(n[, msg])
@@ -1808,10 +1837,12 @@ module.exports = function (chai, _) {
    *     expect(2).to.be.at.most(1, 'nooo why fail??');
    *     expect(2, 'nooo why fail??').to.be.at.most(1);
    *
-   * The alias `.lte` can be used interchangeably with `.most`.
+   * The aliases `.lte` and `.lessThanOrEqual` can be used interchangeably with
+   * `.most`.
    *
    * @name most
    * @alias lte
+   * @alias lessThanOrEqual
    * @param {Number} n
    * @param {String} msg _optional_
    * @namespace BDD
@@ -1877,6 +1908,7 @@ module.exports = function (chai, _) {
 
   Assertion.addMethod('most', assertMost);
   Assertion.addMethod('lte', assertMost);
+  Assertion.addMethod('lessThanOrEqual', assertMost);
 
   /**
    * ### .within(start, finish[, msg])
@@ -1934,7 +1966,7 @@ module.exports = function (chai, _) {
       , errorMessage
       , shouldThrow = true
       , range = (startType === 'date' && finishType === 'date')
-          ? start.toUTCString() + '..' + finish.toUTCString()
+          ? start.toISOString() + '..' + finish.toISOString()
           : start + '..' + finish;
 
     if (doLength && objType !== 'map' && objType !== 'set') {
@@ -2292,7 +2324,7 @@ module.exports = function (chai, _) {
    * a `descriptor`. The problem is that it creates uncertain expectations by
    * asserting that the target either doesn't have a property descriptor with
    * the given key `name`, or that it does have a property descriptor with the
-   * given key `name` but its not deeply equal to the given `descriptor`. It's
+   * given key `name` but it’s not deeply equal to the given `descriptor`. It's
    * often best to identify the exact output that's expected, and then write an
    * assertion that only accepts that exact output.
    *
@@ -3320,8 +3352,9 @@ module.exports = function (chai, _) {
     new Assertion(obj, flagMsg, ssfi, true).is.a('number');
     if (typeof expected !== 'number' || typeof delta !== 'number') {
       flagMsg = flagMsg ? flagMsg + ': ' : '';
+      var deltaMessage = delta === undefined ? ", and a delta is required" : "";
       throw new AssertionError(
-          flagMsg + 'the arguments to closeTo or approximately must be numbers',
+          flagMsg + 'the arguments to closeTo or approximately must be numbers' + deltaMessage,
           undefined,
           ssfi
       );
@@ -3487,6 +3520,14 @@ module.exports = function (chai, _) {
    *     expect(1).to.equal(1); // Recommended
    *     expect(1).to.not.be.oneOf([2, 3, 4]); // Not recommended
    *
+   * It can also be chained with `.contain` or `.include`, which will work with
+   * both arrays and strings:
+   *
+   *     expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy'])
+   *     expect('Today is rainy').to.not.contain.oneOf(['sunny', 'cloudy'])
+   *     expect([1,2,3]).to.contain.oneOf([3,4,5])
+   *     expect([1,2,3]).to.not.contain.oneOf([4,5,6])
+   *
    * `.oneOf` accepts an optional `msg` argument which is a custom error message
    * to show when the assertion fails. The message can also be given as the
    * second argument to `expect`.
@@ -3505,16 +3546,38 @@ module.exports = function (chai, _) {
     if (msg) flag(this, 'message', msg);
     var expected = flag(this, 'object')
       , flagMsg = flag(this, 'message')
-      , ssfi = flag(this, 'ssfi');
+      , ssfi = flag(this, 'ssfi')
+      , contains = flag(this, 'contains')
+      , isDeep = flag(this, 'deep');
     new Assertion(list, flagMsg, ssfi, true).to.be.an('array');
 
-    this.assert(
-        list.indexOf(expected) > -1
-      , 'expected #{this} to be one of #{exp}'
-      , 'expected #{this} to not be one of #{exp}'
-      , list
-      , expected
-    );
+    if (contains) {
+      this.assert(
+        list.some(function(possibility) { return expected.indexOf(possibility) > -1 })
+        , 'expected #{this} to contain one of #{exp}'
+        , 'expected #{this} to not contain one of #{exp}'
+        , list
+        , expected
+      );
+    } else {
+      if (isDeep) {
+        this.assert(
+          list.some(function(possibility) { return _.eql(expected, possibility) })
+          , 'expected #{this} to deeply equal one of #{exp}'
+          , 'expected #{this} to deeply equal one of #{exp}'
+          , list
+          , expected
+        );
+      } else {
+        this.assert(
+          list.indexOf(expected) > -1
+          , 'expected #{this} to be one of #{exp}'
+          , 'expected #{this} to not be one of #{exp}'
+          , list
+          , expected
+        );
+      }
+    }
   }
 
   Assertion.addMethod('oneOf', oneOf);
@@ -6002,7 +6065,7 @@ module.exports = function (chai, util) {
    *     assert.hasAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {three: 'three'}]);
    *     assert.hasAnyDeepKeys(new Set([{one: 'one'}, {two: 'two'}]), [{one: 'one'}, {two: 'two'}]);
    *
-   * @name doesNotHaveAllKeys
+   * @name hasAnyDeepKeys
    * @param {Mixed} object
    * @param {Array|Object} keys
    * @param {String} message
@@ -6436,7 +6499,7 @@ module.exports = function (chai, util) {
    * Asserts that `set1` and `set2` have the same members in the same order.
    * Uses a deep equality check.
    *
-   * assert.sameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { a: 1 }, { b: 2 }, { c: 3 } ], 'same deep ordered members');
+   *     assert.sameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { a: 1 }, { b: 2 }, { c: 3 } ], 'same deep ordered members');
    *
    * @name sameDeepOrderedMembers
    * @param {Array} set1
@@ -6457,8 +6520,8 @@ module.exports = function (chai, util) {
    * Asserts that `set1` and `set2` don't have the same members in the same
    * order. Uses a deep equality check.
    *
-   * assert.notSameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { a: 1 }, { b: 2 }, { z: 5 } ], 'not same deep ordered members');
-   * assert.notSameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { b: 2 }, { a: 1 }, { c: 3 } ], 'not same deep ordered members');
+   *     assert.notSameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { a: 1 }, { b: 2 }, { z: 5 } ], 'not same deep ordered members');
+   *     assert.notSameDeepOrderedMembers([ { a: 1 }, { b: 2 }, { c: 3 } ], [ { b: 2 }, { a: 1 }, { c: 3 } ], 'not same deep ordered members');
    *
    * @name notSameDeepOrderedMembers
    * @param {Array} set1
@@ -6878,7 +6941,7 @@ module.exports = function (chai, util) {
   };
 
   /**
-   * ### .increasesButNotBy(function, object, property, [message])
+   * ### .increasesButNotBy(function, object, property, delta, [message])
    *
    * Asserts that a function does not increase a numeric object property or function's return value by an amount (delta).
    *
@@ -7008,7 +7071,7 @@ module.exports = function (chai, util) {
    *     var fn = function() { obj.val = 5 };
    *     assert.doesNotDecreaseBy(fn, obj, 'val', 1);
    *
-   * @name doesNotDecrease
+   * @name doesNotDecreaseBy
    * @param {Function} modifier function
    * @param {Object} object or getter function
    * @param {String} property name _optional_
@@ -7353,7 +7416,8 @@ module.exports = function (chai, util) {
       if (this instanceof String
           || this instanceof Number
           || this instanceof Boolean
-          || typeof Symbol === 'function' && this instanceof Symbol) {
+          || typeof Symbol === 'function' && this instanceof Symbol
+          || typeof BigInt === 'function' && this instanceof BigInt) {
         return new Assertion(this.valueOf(), null, shouldGetter);
       }
       return new Assertion(this, null, shouldGetter);
@@ -8002,7 +8066,7 @@ module.exports = function expectTypes(obj, types) {
   }
 };
 
-},{"./flag":15,"assertion-error":33,"type-detect":38}],15:[function(require,module,exports){
+},{"./flag":15,"assertion-error":33,"type-detect":39}],15:[function(require,module,exports){
 /*!
  * Chai - flag utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
@@ -8061,34 +8125,6 @@ module.exports = function getActual(obj, args) {
 
 },{}],17:[function(require,module,exports){
 /*!
- * Chai - getEnumerableProperties utility
- * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
- * MIT Licensed
- */
-
-/**
- * ### .getEnumerableProperties(object)
- *
- * This allows the retrieval of enumerable property names of an object,
- * inherited or not.
- *
- * @param {Object} object
- * @returns {Array}
- * @namespace Utils
- * @name getEnumerableProperties
- * @api public
- */
-
-module.exports = function getEnumerableProperties(object) {
-  var result = [];
-  for (var name in object) {
-    result.push(name);
-  }
-  return result;
-};
-
-},{}],18:[function(require,module,exports){
-/*!
  * Chai - message composition utility
  * Copyright(c) 2012-2014 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
@@ -8139,7 +8175,64 @@ module.exports = function getMessage(obj, args) {
   return flagMsg ? flagMsg + ': ' + msg : msg;
 };
 
-},{"./flag":15,"./getActual":16,"./objDisplay":26}],19:[function(require,module,exports){
+},{"./flag":15,"./getActual":16,"./objDisplay":26}],18:[function(require,module,exports){
+var type = require('type-detect');
+
+var flag = require('./flag');
+
+function isObjectType(obj) {
+  var objectType = type(obj);
+  var objectTypes = ['Array', 'Object', 'function'];
+
+  return objectTypes.indexOf(objectType) !== -1;
+}
+
+/**
+ * ### .getOperator(message)
+ *
+ * Extract the operator from error message.
+ * Operator defined is based on below link
+ * https://nodejs.org/api/assert.html#assert_assert.
+ *
+ * Returns the `operator` or `undefined` value for an Assertion.
+ *
+ * @param {Object} object (constructed Assertion)
+ * @param {Arguments} chai.Assertion.prototype.assert arguments
+ * @namespace Utils
+ * @name getOperator
+ * @api public
+ */
+
+module.exports = function getOperator(obj, args) {
+  var operator = flag(obj, 'operator');
+  var negate = flag(obj, 'negate');
+  var expected = args[3];
+  var msg = negate ? args[2] : args[1];
+
+  if (operator) {
+    return operator;
+  }
+
+  if (typeof msg === 'function') msg = msg();
+
+  msg = msg || '';
+  if (!msg) {
+    return undefined;
+  }
+
+  if (/\shave\s/.test(msg)) {
+    return undefined;
+  }
+
+  var isObject = isObjectType(expected);
+  if (/\snot\s/.test(msg)) {
+    return isObject ? 'notDeepStrictEqual' : 'notStrictEqual';
+  }
+
+  return isObject ? 'deepStrictEqual' : 'strictEqual';
+};
+
+},{"./flag":15,"type-detect":39}],19:[function(require,module,exports){
 /*!
  * Chai - getOwnEnumerableProperties utility
  * Copyright(c) 2011-2016 Jake Luer <jake@alogicalparadox.com>
@@ -8411,13 +8504,17 @@ exports.isProxyEnabled = require('./isProxyEnabled');
 
 exports.isNaN = require('./isNaN');
 
-},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":18,"./getOwnEnumerableProperties":19,"./getOwnEnumerablePropertySymbols":20,"./inspect":23,"./isNaN":24,"./isProxyEnabled":25,"./objDisplay":26,"./overwriteChainableMethod":27,"./overwriteMethod":28,"./overwriteProperty":29,"./proxify":30,"./test":31,"./transferFlags":32,"check-error":34,"deep-eql":35,"get-func-name":36,"pathval":37,"type-detect":38}],23:[function(require,module,exports){
+/*!
+ * getOperator method
+ */
+
+exports.getOperator = require('./getOperator');
+},{"./addChainableMethod":9,"./addLengthGuard":10,"./addMethod":11,"./addProperty":12,"./compareByInspect":13,"./expectTypes":14,"./flag":15,"./getActual":16,"./getMessage":17,"./getOperator":18,"./getOwnEnumerableProperties":19,"./getOwnEnumerablePropertySymbols":20,"./inspect":23,"./isNaN":24,"./isProxyEnabled":25,"./objDisplay":26,"./overwriteChainableMethod":27,"./overwriteMethod":28,"./overwriteProperty":29,"./proxify":30,"./test":31,"./transferFlags":32,"check-error":34,"deep-eql":35,"get-func-name":36,"pathval":38,"type-detect":39}],23:[function(require,module,exports){
 // This is (almost) directly from Node.js utils
 // https://github.com/joyent/node/blob/f8c335d0caf47f16d31413f89aa28eda3878e3aa/lib/util.js
 
-var getName = require('get-func-name');
-var getProperties = require('./getProperties');
-var getEnumerableProperties = require('./getEnumerableProperties');
+require('get-func-name');
+var loupe = require('loupe');
 var config = require('../config');
 
 module.exports = inspect;
@@ -8438,358 +8535,16 @@ module.exports = inspect;
  * @name inspect
  */
 function inspect(obj, showHidden, depth, colors) {
-  var ctx = {
+  var options = {
+    colors: colors,
+    depth: (typeof depth === 'undefined' ? 2 : depth),
     showHidden: showHidden,
-    seen: [],
-    stylize: function (str) { return str; }
+    truncate: config.truncateThreshold ? config.truncateThreshold : Infinity,
   };
-  return formatValue(ctx, obj, (typeof depth === 'undefined' ? 2 : depth));
+  return loupe.inspect(obj, options);
 }
 
-// Returns true if object is a DOM element.
-var isDOMElement = function (object) {
-  if (typeof HTMLElement === 'object') {
-    return object instanceof HTMLElement;
-  } else {
-    return object &&
-      typeof object === 'object' &&
-      'nodeType' in object &&
-      object.nodeType === 1 &&
-      typeof object.nodeName === 'string';
-  }
-};
-
-function formatValue(ctx, value, recurseTimes) {
-  // Provide a hook for user-specified inspect functions.
-  // Check that value is an object with an inspect function on it
-  if (value && typeof value.inspect === 'function' &&
-      // Filter out the util module, it's inspect function is special
-      value.inspect !== exports.inspect &&
-      // Also filter out any prototype objects using the circular check.
-      !(value.constructor && value.constructor.prototype === value)) {
-    var ret = value.inspect(recurseTimes, ctx);
-    if (typeof ret !== 'string') {
-      ret = formatValue(ctx, ret, recurseTimes);
-    }
-    return ret;
-  }
-
-  // Primitive types cannot have properties
-  var primitive = formatPrimitive(ctx, value);
-  if (primitive) {
-    return primitive;
-  }
-
-  // If this is a DOM element, try to get the outer HTML.
-  if (isDOMElement(value)) {
-    if ('outerHTML' in value) {
-      return value.outerHTML;
-      // This value does not have an outerHTML attribute,
-      //   it could still be an XML element
-    } else {
-      // Attempt to serialize it
-      try {
-        if (document.xmlVersion) {
-          var xmlSerializer = new XMLSerializer();
-          return xmlSerializer.serializeToString(value);
-        } else {
-          // Firefox 11- do not support outerHTML
-          //   It does, however, support innerHTML
-          //   Use the following to render the element
-          var ns = "http://www.w3.org/1999/xhtml";
-          var container = document.createElementNS(ns, '_');
-
-          container.appendChild(value.cloneNode(false));
-          var html = container.innerHTML
-            .replace('><', '>' + value.innerHTML + '<');
-          container.innerHTML = '';
-          return html;
-        }
-      } catch (err) {
-        // This could be a non-native DOM implementation,
-        //   continue with the normal flow:
-        //   printing the element as if it is an object.
-      }
-    }
-  }
-
-  // Look up the keys of the object.
-  var visibleKeys = getEnumerableProperties(value);
-  var keys = ctx.showHidden ? getProperties(value) : visibleKeys;
-
-  var name, nameSuffix;
-
-  // Some type of object without properties can be shortcut.
-  // In IE, errors have a single `stack` property, or if they are vanilla `Error`,
-  // a `stack` plus `description` property; ignore those for consistency.
-  if (keys.length === 0 || (isError(value) && (
-      (keys.length === 1 && keys[0] === 'stack') ||
-      (keys.length === 2 && keys[0] === 'description' && keys[1] === 'stack')
-     ))) {
-    if (typeof value === 'function') {
-      name = getName(value);
-      nameSuffix = name ? ': ' + name : '';
-      return ctx.stylize('[Function' + nameSuffix + ']', 'special');
-    }
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    }
-    if (isDate(value)) {
-      return ctx.stylize(Date.prototype.toUTCString.call(value), 'date');
-    }
-    if (isError(value)) {
-      return formatError(value);
-    }
-  }
-
-  var base = ''
-    , array = false
-    , typedArray = false
-    , braces = ['{', '}'];
-
-  if (isTypedArray(value)) {
-    typedArray = true;
-    braces = ['[', ']'];
-  }
-
-  // Make Array say that they are Array
-  if (isArray(value)) {
-    array = true;
-    braces = ['[', ']'];
-  }
-
-  // Make functions say that they are functions
-  if (typeof value === 'function') {
-    name = getName(value);
-    nameSuffix = name ? ': ' + name : '';
-    base = ' [Function' + nameSuffix + ']';
-  }
-
-  // Make RegExps say that they are RegExps
-  if (isRegExp(value)) {
-    base = ' ' + RegExp.prototype.toString.call(value);
-  }
-
-  // Make dates with properties first say the date
-  if (isDate(value)) {
-    base = ' ' + Date.prototype.toUTCString.call(value);
-  }
-
-  // Make error with message first say the error
-  if (isError(value)) {
-    return formatError(value);
-  }
-
-  if (keys.length === 0 && (!array || value.length == 0)) {
-    return braces[0] + base + braces[1];
-  }
-
-  if (recurseTimes < 0) {
-    if (isRegExp(value)) {
-      return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    } else {
-      return ctx.stylize('[Object]', 'special');
-    }
-  }
-
-  ctx.seen.push(value);
-
-  var output;
-  if (array) {
-    output = formatArray(ctx, value, recurseTimes, visibleKeys, keys);
-  } else if (typedArray) {
-    return formatTypedArray(value);
-  } else {
-    output = keys.map(function(key) {
-      return formatProperty(ctx, value, recurseTimes, visibleKeys, key, array);
-    });
-  }
-
-  ctx.seen.pop();
-
-  return reduceToSingleString(output, base, braces);
-}
-
-function formatPrimitive(ctx, value) {
-  switch (typeof value) {
-    case 'undefined':
-      return ctx.stylize('undefined', 'undefined');
-
-    case 'string':
-      var simple = '\'' + JSON.stringify(value).replace(/^"|"$/g, '')
-                                               .replace(/'/g, "\\'")
-                                               .replace(/\\"/g, '"') + '\'';
-      return ctx.stylize(simple, 'string');
-
-    case 'number':
-      if (value === 0 && (1/value) === -Infinity) {
-        return ctx.stylize('-0', 'number');
-      }
-      return ctx.stylize('' + value, 'number');
-
-    case 'boolean':
-      return ctx.stylize('' + value, 'boolean');
-
-    case 'symbol':
-      return ctx.stylize(value.toString(), 'symbol');
-  }
-  // For some reason typeof null is "object", so special case here.
-  if (value === null) {
-    return ctx.stylize('null', 'null');
-  }
-}
-
-function formatError(value) {
-  return '[' + Error.prototype.toString.call(value) + ']';
-}
-
-function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
-  var output = [];
-  for (var i = 0, l = value.length; i < l; ++i) {
-    if (Object.prototype.hasOwnProperty.call(value, String(i))) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          String(i), true));
-    } else {
-      output.push('');
-    }
-  }
-
-  keys.forEach(function(key) {
-    if (!key.match(/^\d+$/)) {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-          key, true));
-    }
-  });
-  return output;
-}
-
-function formatTypedArray(value) {
-  var str = '[ ';
-
-  for (var i = 0; i < value.length; ++i) {
-    if (str.length >= config.truncateThreshold - 7) {
-      str += '...';
-      break;
-    }
-    str += value[i] + ', ';
-  }
-  str += ' ]';
-
-  // Removing trailing `, ` if the array was not truncated
-  if (str.indexOf(',  ]') !== -1) {
-    str = str.replace(',  ]', ' ]');
-  }
-
-  return str;
-}
-
-function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
-  var name;
-  var propDescriptor = Object.getOwnPropertyDescriptor(value, key);
-  var str;
-
-  if (propDescriptor) {
-    if (propDescriptor.get) {
-      if (propDescriptor.set) {
-        str = ctx.stylize('[Getter/Setter]', 'special');
-      } else {
-        str = ctx.stylize('[Getter]', 'special');
-      }
-    } else {
-      if (propDescriptor.set) {
-        str = ctx.stylize('[Setter]', 'special');
-      }
-    }
-  }
-  if (visibleKeys.indexOf(key) < 0) {
-    name = '[' + key + ']';
-  }
-  if (!str) {
-    if (ctx.seen.indexOf(value[key]) < 0) {
-      if (recurseTimes === null) {
-        str = formatValue(ctx, value[key], null);
-      } else {
-        str = formatValue(ctx, value[key], recurseTimes - 1);
-      }
-      if (str.indexOf('\n') > -1) {
-        if (array) {
-          str = str.split('\n').map(function(line) {
-            return '  ' + line;
-          }).join('\n').substr(2);
-        } else {
-          str = '\n' + str.split('\n').map(function(line) {
-            return '   ' + line;
-          }).join('\n');
-        }
-      }
-    } else {
-      str = ctx.stylize('[Circular]', 'special');
-    }
-  }
-  if (typeof name === 'undefined') {
-    if (array && key.match(/^\d+$/)) {
-      return str;
-    }
-    name = JSON.stringify('' + key);
-    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
-      name = name.substr(1, name.length - 2);
-      name = ctx.stylize(name, 'name');
-    } else {
-      name = name.replace(/'/g, "\\'")
-                 .replace(/\\"/g, '"')
-                 .replace(/(^"|"$)/g, "'");
-      name = ctx.stylize(name, 'string');
-    }
-  }
-
-  return name + ': ' + str;
-}
-
-function reduceToSingleString(output, base, braces) {
-  var length = output.reduce(function(prev, cur) {
-    return prev + cur.length + 1;
-  }, 0);
-
-  if (length > 60) {
-    return braces[0] +
-           (base === '' ? '' : base + '\n ') +
-           ' ' +
-           output.join(',\n  ') +
-           ' ' +
-           braces[1];
-  }
-
-  return braces[0] + base + ' ' + output.join(', ') + ' ' + braces[1];
-}
-
-function isTypedArray(ar) {
-  // Unfortunately there's no way to check if an object is a TypedArray
-  // We have to check if it's one of these types
-  return (typeof ar === 'object' && /\w+Array]$/.test(objectToString(ar)));
-}
-
-function isArray(ar) {
-  return Array.isArray(ar) ||
-         (typeof ar === 'object' && objectToString(ar) === '[object Array]');
-}
-
-function isRegExp(re) {
-  return typeof re === 'object' && objectToString(re) === '[object RegExp]';
-}
-
-function isDate(d) {
-  return typeof d === 'object' && objectToString(d) === '[object Date]';
-}
-
-function isError(e) {
-  return typeof e === 'object' && objectToString(e) === '[object Error]';
-}
-
-function objectToString(o) {
-  return Object.prototype.toString.call(o);
-}
-
-},{"../config":4,"./getEnumerableProperties":17,"./getProperties":21,"get-func-name":36}],24:[function(require,module,exports){
+},{"../config":4,"get-func-name":36,"loupe":37}],24:[function(require,module,exports){
 /*!
  * Chai - isNaN utility
  * Copyright(c) 2012-2015 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
@@ -9684,10 +9439,10 @@ function FakeMap() {
 }
 
 FakeMap.prototype = {
-  get: function getMap(key) {
+  get: function get(key) {
     return key[this._key];
   },
-  set: function setMap(key, value) {
+  set: function set(key, value) {
     if (Object.isExtensible(key)) {
       Object.defineProperty(key, this._key, {
         value: value,
@@ -9879,8 +9634,9 @@ function extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandTyp
     case 'function':
     case 'WeakMap':
     case 'WeakSet':
-    case 'Error':
       return leftHandOperand === rightHandOperand;
+    case 'Error':
+      return keysEqual(leftHandOperand, rightHandOperand, [ 'name', 'message', 'code' ], options);
     case 'Arguments':
     case 'Int8Array':
     case 'Uint8Array':
@@ -9905,6 +9661,19 @@ function extensiveDeepEqualByType(leftHandOperand, rightHandOperand, leftHandTyp
       return entriesEqual(leftHandOperand, rightHandOperand, options);
     case 'Map':
       return entriesEqual(leftHandOperand, rightHandOperand, options);
+    case 'Temporal.PlainDate':
+    case 'Temporal.PlainTime':
+    case 'Temporal.PlainDateTime':
+    case 'Temporal.Instant':
+    case 'Temporal.ZonedDateTime':
+    case 'Temporal.PlainYearMonth':
+    case 'Temporal.PlainMonthDay':
+      return leftHandOperand.equals(rightHandOperand);
+    case 'Temporal.Duration':
+      return leftHandOperand.total('nanoseconds') === rightHandOperand.total('nanoseconds');
+    case 'Temporal.TimeZone':
+    case 'Temporal.Calendar':
+      return leftHandOperand.toString() === rightHandOperand.toString();
     default:
       return objectEqual(leftHandOperand, rightHandOperand, options);
   }
@@ -10050,6 +9819,11 @@ function getEnumerableKeys(target) {
   return keys;
 }
 
+function getNonEnumerableSymbols(target) {
+  var keys = Object.getOwnPropertySymbols(target);
+  return keys;
+}
+
 /*!
  * Determines if two objects have matching values, given a set of keys. Defers to deepEqual for the equality check of
  * each key. If any value of the given key is not equal, the function will return false (early).
@@ -10082,14 +9856,16 @@ function keysEqual(leftHandOperand, rightHandOperand, keys, options) {
  * @param {Object} [options] (Optional)
  * @return {Boolean} result
  */
-
 function objectEqual(leftHandOperand, rightHandOperand, options) {
   var leftHandKeys = getEnumerableKeys(leftHandOperand);
   var rightHandKeys = getEnumerableKeys(rightHandOperand);
+  var leftHandSymbols = getNonEnumerableSymbols(leftHandOperand);
+  var rightHandSymbols = getNonEnumerableSymbols(rightHandOperand);
+  leftHandKeys = leftHandKeys.concat(leftHandSymbols);
+  rightHandKeys = rightHandKeys.concat(rightHandSymbols);
+
   if (leftHandKeys.length && leftHandKeys.length === rightHandKeys.length) {
-    leftHandKeys.sort();
-    rightHandKeys.sort();
-    if (iterableEqual(leftHandKeys, rightHandKeys) === false) {
+    if (iterableEqual(mapSymbols(leftHandKeys).sort(), mapSymbols(rightHandKeys).sort()) === false) {
       return false;
     }
     return keysEqual(leftHandOperand, rightHandOperand, leftHandKeys, options);
@@ -10126,7 +9902,17 @@ function isPrimitive(value) {
   return value === null || typeof value !== 'object';
 }
 
-},{"type-detect":38}],36:[function(require,module,exports){
+function mapSymbols(arr) {
+  return arr.map(function mapSymbol(entry) {
+    if (typeof entry === 'symbol') {
+      return entry.toString();
+    }
+
+    return entry;
+  });
+}
+
+},{"type-detect":39}],36:[function(require,module,exports){
 
 /* !
  * Chai - getFuncName utility
@@ -10172,6 +9958,853 @@ function getFuncName(aFunc) {
 module.exports = getFuncName;
 
 },{}],37:[function(require,module,exports){
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.loupe = {}));
+}(this, (function (exports) {
+  function _typeof(obj) {
+    "@babel/helpers - typeof";
+
+    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+      _typeof = function (obj) {
+        return typeof obj;
+      };
+    } else {
+      _typeof = function (obj) {
+        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+      };
+    }
+
+    return _typeof(obj);
+  }
+
+  function _slicedToArray(arr, i) {
+    return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest();
+  }
+
+  function _arrayWithHoles(arr) {
+    if (Array.isArray(arr)) return arr;
+  }
+
+  function _iterableToArrayLimit(arr, i) {
+    if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return;
+    var _arr = [];
+    var _n = true;
+    var _d = false;
+    var _e = undefined;
+
+    try {
+      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+        _arr.push(_s.value);
+
+        if (i && _arr.length === i) break;
+      }
+    } catch (err) {
+      _d = true;
+      _e = err;
+    } finally {
+      try {
+        if (!_n && _i["return"] != null) _i["return"]();
+      } finally {
+        if (_d) throw _e;
+      }
+    }
+
+    return _arr;
+  }
+
+  function _unsupportedIterableToArray(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(o);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+  }
+
+  function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+
+    return arr2;
+  }
+
+  function _nonIterableRest() {
+    throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var ansiColors = {
+    bold: ['1', '22'],
+    dim: ['2', '22'],
+    italic: ['3', '23'],
+    underline: ['4', '24'],
+    // 5 & 6 are blinking
+    inverse: ['7', '27'],
+    hidden: ['8', '28'],
+    strike: ['9', '29'],
+    // 10-20 are fonts
+    // 21-29 are resets for 1-9
+    black: ['30', '39'],
+    red: ['31', '39'],
+    green: ['32', '39'],
+    yellow: ['33', '39'],
+    blue: ['34', '39'],
+    magenta: ['35', '39'],
+    cyan: ['36', '39'],
+    white: ['37', '39'],
+    brightblack: ['30;1', '39'],
+    brightred: ['31;1', '39'],
+    brightgreen: ['32;1', '39'],
+    brightyellow: ['33;1', '39'],
+    brightblue: ['34;1', '39'],
+    brightmagenta: ['35;1', '39'],
+    brightcyan: ['36;1', '39'],
+    brightwhite: ['37;1', '39'],
+    grey: ['90', '39']
+  };
+  var styles = {
+    special: 'cyan',
+    number: 'yellow',
+    bigint: 'yellow',
+    boolean: 'yellow',
+    undefined: 'grey',
+    null: 'bold',
+    string: 'green',
+    symbol: 'green',
+    date: 'magenta',
+    regexp: 'red'
+  };
+  var truncator = '…';
+
+  function colorise(value, styleType) {
+    var color = ansiColors[styles[styleType]] || ansiColors[styleType];
+
+    if (!color) {
+      return String(value);
+    }
+
+    return "\x1B[".concat(color[0], "m").concat(String(value), "\x1B[").concat(color[1], "m");
+  }
+
+  function normaliseOptions() {
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref$showHidden = _ref.showHidden,
+        showHidden = _ref$showHidden === void 0 ? false : _ref$showHidden,
+        _ref$depth = _ref.depth,
+        depth = _ref$depth === void 0 ? 2 : _ref$depth,
+        _ref$colors = _ref.colors,
+        colors = _ref$colors === void 0 ? false : _ref$colors,
+        _ref$customInspect = _ref.customInspect,
+        customInspect = _ref$customInspect === void 0 ? true : _ref$customInspect,
+        _ref$showProxy = _ref.showProxy,
+        showProxy = _ref$showProxy === void 0 ? false : _ref$showProxy,
+        _ref$maxArrayLength = _ref.maxArrayLength,
+        maxArrayLength = _ref$maxArrayLength === void 0 ? Infinity : _ref$maxArrayLength,
+        _ref$breakLength = _ref.breakLength,
+        breakLength = _ref$breakLength === void 0 ? Infinity : _ref$breakLength,
+        _ref$seen = _ref.seen,
+        seen = _ref$seen === void 0 ? [] : _ref$seen,
+        _ref$truncate = _ref.truncate,
+        truncate = _ref$truncate === void 0 ? Infinity : _ref$truncate,
+        _ref$stylize = _ref.stylize,
+        stylize = _ref$stylize === void 0 ? String : _ref$stylize;
+
+    var options = {
+      showHidden: Boolean(showHidden),
+      depth: Number(depth),
+      colors: Boolean(colors),
+      customInspect: Boolean(customInspect),
+      showProxy: Boolean(showProxy),
+      maxArrayLength: Number(maxArrayLength),
+      breakLength: Number(breakLength),
+      truncate: Number(truncate),
+      seen: seen,
+      stylize: stylize
+    };
+
+    if (options.colors) {
+      options.stylize = colorise;
+    }
+
+    return options;
+  }
+  function truncate(string, length) {
+    var tail = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : truncator;
+    string = String(string);
+    var tailLength = tail.length;
+    var stringLength = string.length;
+
+    if (tailLength > length && stringLength > tailLength) {
+      return tail;
+    }
+
+    if (stringLength > length && stringLength > tailLength) {
+      return "".concat(string.slice(0, length - tailLength)).concat(tail);
+    }
+
+    return string;
+  } // eslint-disable-next-line complexity
+
+  function inspectList(list, options, inspectItem) {
+    var separator = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : ', ';
+    inspectItem = inspectItem || options.inspect;
+    var size = list.length;
+    if (size === 0) return '';
+    var originalLength = options.truncate;
+    var output = '';
+    var peek = '';
+    var truncated = '';
+
+    for (var i = 0; i < size; i += 1) {
+      var last = i + 1 === list.length;
+      var secondToLast = i + 2 === list.length;
+      truncated = "".concat(truncator, "(").concat(list.length - i, ")");
+      var value = list[i]; // If there is more than one remaining we need to account for a separator of `, `
+
+      options.truncate = originalLength - output.length - (last ? 0 : separator.length);
+      var string = peek || inspectItem(value, options) + (last ? '' : separator);
+      var nextLength = output.length + string.length;
+      var truncatedLength = nextLength + truncated.length; // If this is the last element, and adding it would
+      // take us over length, but adding the truncator wouldn't - then break now
+
+      if (last && nextLength > originalLength && output.length + truncated.length <= originalLength) {
+        break;
+      } // If this isn't the last or second to last element to scan,
+      // but the string is already over length then break here
+
+
+      if (!last && !secondToLast && truncatedLength > originalLength) {
+        break;
+      } // Peek at the next string to determine if we should
+      // break early before adding this item to the output
+
+
+      peek = last ? '' : inspectItem(list[i + 1], options) + (secondToLast ? '' : separator); // If we have one element left, but this element and
+      // the next takes over length, the break early
+
+      if (!last && secondToLast && truncatedLength > originalLength && nextLength + peek.length > originalLength) {
+        break;
+      }
+
+      output += string; // If the next element takes us to length -
+      // but there are more after that, then we should truncate now
+
+      if (!last && !secondToLast && nextLength + peek.length >= originalLength) {
+        truncated = "".concat(truncator, "(").concat(list.length - i - 1, ")");
+        break;
+      }
+
+      truncated = '';
+    }
+
+    return "".concat(output).concat(truncated);
+  }
+
+  function quoteComplexKey(key) {
+    if (key.match(/^[a-zA-Z_][a-zA-Z_0-9]*$/)) {
+      return key;
+    }
+
+    return JSON.stringify(key).replace(/'/g, "\\'").replace(/\\"/g, '"').replace(/(^"|"$)/g, "'");
+  }
+
+  function inspectProperty(_ref2, options) {
+    var _ref3 = _slicedToArray(_ref2, 2),
+        key = _ref3[0],
+        value = _ref3[1];
+
+    options.truncate -= 2;
+
+    if (typeof key === 'string') {
+      key = quoteComplexKey(key);
+    } else if (typeof key !== 'number') {
+      key = "[".concat(options.inspect(key, options), "]");
+    }
+
+    options.truncate -= key.length;
+    value = options.inspect(value, options);
+    return "".concat(key, ": ").concat(value);
+  }
+
+  function inspectArray(array, options) {
+    // Object.keys will always output the Array indices first, so we can slice by
+    // `array.length` to get non-index properties
+    var nonIndexProperties = Object.keys(array).slice(array.length);
+    if (!array.length && !nonIndexProperties.length) return '[]';
+    options.truncate -= 4;
+    var listContents = inspectList(array, options);
+    options.truncate -= listContents.length;
+    var propertyContents = '';
+
+    if (nonIndexProperties.length) {
+      propertyContents = inspectList(nonIndexProperties.map(function (key) {
+        return [key, array[key]];
+      }), options, inspectProperty);
+    }
+
+    return "[ ".concat(listContents).concat(propertyContents ? ", ".concat(propertyContents) : '', " ]");
+  }
+
+  /* !
+   * Chai - getFuncName utility
+   * Copyright(c) 2012-2016 Jake Luer <jake@alogicalparadox.com>
+   * MIT Licensed
+   */
+
+  /**
+   * ### .getFuncName(constructorFn)
+   *
+   * Returns the name of a function.
+   * When a non-function instance is passed, returns `null`.
+   * This also includes a polyfill function if `aFunc.name` is not defined.
+   *
+   * @name getFuncName
+   * @param {Function} funct
+   * @namespace Utils
+   * @api public
+   */
+
+  var toString = Function.prototype.toString;
+  var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
+  function getFuncName(aFunc) {
+    if (typeof aFunc !== 'function') {
+      return null;
+    }
+
+    var name = '';
+    if (typeof Function.prototype.name === 'undefined' && typeof aFunc.name === 'undefined') {
+      // Here we run a polyfill if Function does not support the `name` property and if aFunc.name is not defined
+      var match = toString.call(aFunc).match(functionNameMatch);
+      if (match) {
+        name = match[1];
+      }
+    } else {
+      // If we've got a `name` property we just use it
+      name = aFunc.name;
+    }
+
+    return name;
+  }
+
+  var getFuncName_1 = getFuncName;
+
+  var getArrayName = function getArrayName(array) {
+    // We need to special case Node.js' Buffers, which report to be Uint8Array
+    if (typeof Buffer === 'function' && array instanceof Buffer) {
+      return 'Buffer';
+    }
+
+    if (array[Symbol.toStringTag]) {
+      return array[Symbol.toStringTag];
+    }
+
+    return getFuncName_1(array.constructor);
+  };
+
+  function inspectTypedArray(array, options) {
+    var name = getArrayName(array);
+    options.truncate -= name.length + 4; // Object.keys will always output the Array indices first, so we can slice by
+    // `array.length` to get non-index properties
+
+    var nonIndexProperties = Object.keys(array).slice(array.length);
+    if (!array.length && !nonIndexProperties.length) return "".concat(name, "[]"); // As we know TypedArrays only contain Unsigned Integers, we can skip inspecting each one and simply
+    // stylise the toString() value of them
+
+    var output = '';
+
+    for (var i = 0; i < array.length; i++) {
+      var string = "".concat(options.stylize(truncate(array[i], options.truncate), 'number')).concat(i === array.length - 1 ? '' : ', ');
+      options.truncate -= string.length;
+
+      if (array[i] !== array.length && options.truncate <= 3) {
+        output += "".concat(truncator, "(").concat(array.length - array[i] + 1, ")");
+        break;
+      }
+
+      output += string;
+    }
+
+    var propertyContents = '';
+
+    if (nonIndexProperties.length) {
+      propertyContents = inspectList(nonIndexProperties.map(function (key) {
+        return [key, array[key]];
+      }), options, inspectProperty);
+    }
+
+    return "".concat(name, "[ ").concat(output).concat(propertyContents ? ", ".concat(propertyContents) : '', " ]");
+  }
+
+  function inspectDate(dateObject, options) {
+    // If we need to - truncate the time portion, but never the date
+    var split = dateObject.toJSON().split('T');
+    var date = split[0];
+    return options.stylize("".concat(date, "T").concat(truncate(split[1], options.truncate - date.length - 1)), 'date');
+  }
+
+  function inspectFunction(func, options) {
+    var name = getFuncName_1(func);
+
+    if (!name) {
+      return options.stylize('[Function]', 'special');
+    }
+
+    return options.stylize("[Function ".concat(truncate(name, options.truncate - 11), "]"), 'special');
+  }
+
+  function inspectMapEntry(_ref, options) {
+    var _ref2 = _slicedToArray(_ref, 2),
+        key = _ref2[0],
+        value = _ref2[1];
+
+    options.truncate -= 4;
+    key = options.inspect(key, options);
+    options.truncate -= key.length;
+    value = options.inspect(value, options);
+    return "".concat(key, " => ").concat(value);
+  } // IE11 doesn't support `map.entries()`
+
+
+  function mapToEntries(map) {
+    var entries = [];
+    map.forEach(function (value, key) {
+      entries.push([key, value]);
+    });
+    return entries;
+  }
+
+  function inspectMap(map, options) {
+    var size = map.size - 1;
+
+    if (size <= 0) {
+      return 'Map{}';
+    }
+
+    options.truncate -= 7;
+    return "Map{ ".concat(inspectList(mapToEntries(map), options, inspectMapEntry), " }");
+  }
+
+  var isNaN = Number.isNaN || function (i) {
+    return i !== i;
+  }; // eslint-disable-line no-self-compare
+
+
+  function inspectNumber(number, options) {
+    if (isNaN(number)) {
+      return options.stylize('NaN', 'number');
+    }
+
+    if (number === Infinity) {
+      return options.stylize('Infinity', 'number');
+    }
+
+    if (number === -Infinity) {
+      return options.stylize('-Infinity', 'number');
+    }
+
+    if (number === 0) {
+      return options.stylize(1 / number === Infinity ? '+0' : '-0', 'number');
+    }
+
+    return options.stylize(truncate(number, options.truncate), 'number');
+  }
+
+  function inspectBigInt(number, options) {
+    var nums = truncate(number.toString(), options.truncate - 1);
+    if (nums !== truncator) nums += 'n';
+    return options.stylize(nums, 'bigint');
+  }
+
+  function inspectRegExp(value, options) {
+    var flags = value.toString().split('/')[2];
+    var sourceLength = options.truncate - (2 + flags.length);
+    var source = value.source;
+    return options.stylize("/".concat(truncate(source, sourceLength), "/").concat(flags), 'regexp');
+  }
+
+  function arrayFromSet(set) {
+    var values = [];
+    set.forEach(function (value) {
+      values.push(value);
+    });
+    return values;
+  }
+
+  function inspectSet(set, options) {
+    if (set.size === 0) return 'Set{}';
+    options.truncate -= 7;
+    return "Set{ ".concat(inspectList(arrayFromSet(set), options), " }");
+  }
+
+  var stringEscapeChars = new RegExp("['\\u0000-\\u001f\\u007f-\\u009f\\u00ad\\u0600-\\u0604\\u070f\\u17b4\\u17b5" + "\\u200c-\\u200f\\u2028-\\u202f\\u2060-\\u206f\\ufeff\\ufff0-\\uffff]", 'g');
+  var escapeCharacters = {
+    '\b': '\\b',
+    '\t': '\\t',
+    '\n': '\\n',
+    '\f': '\\f',
+    '\r': '\\r',
+    "'": "\\'",
+    '\\': '\\\\'
+  };
+  var hex = 16;
+  var unicodeLength = 4;
+
+  function escape(char) {
+    return escapeCharacters[char] || "\\u".concat("0000".concat(char.charCodeAt(0).toString(hex)).slice(-unicodeLength));
+  }
+
+  function inspectString(string, options) {
+    if (stringEscapeChars.test(string)) {
+      string = string.replace(stringEscapeChars, escape);
+    }
+
+    return options.stylize("'".concat(truncate(string, options.truncate - 2), "'"), 'string');
+  }
+
+  function inspectSymbol(value) {
+    if ('description' in Symbol.prototype) {
+      return value.description ? "Symbol(".concat(value.description, ")") : 'Symbol()';
+    }
+
+    return value.toString();
+  }
+
+  var getPromiseValue = function getPromiseValue() {
+    return 'Promise{…}';
+  };
+
+  try {
+    var _process$binding = process.binding('util'),
+        getPromiseDetails = _process$binding.getPromiseDetails,
+        kPending = _process$binding.kPending,
+        kRejected = _process$binding.kRejected;
+
+    if (Array.isArray(getPromiseDetails(Promise.resolve()))) {
+      getPromiseValue = function getPromiseValue(value, options) {
+        var _getPromiseDetails = getPromiseDetails(value),
+            _getPromiseDetails2 = _slicedToArray(_getPromiseDetails, 2),
+            state = _getPromiseDetails2[0],
+            innerValue = _getPromiseDetails2[1];
+
+        if (state === kPending) {
+          return 'Promise{<pending>}';
+        }
+
+        return "Promise".concat(state === kRejected ? '!' : '', "{").concat(options.inspect(innerValue, options), "}");
+      };
+    }
+  } catch (notNode) {
+    /* ignore */
+  }
+
+  var inspectPromise = getPromiseValue;
+
+  function inspectObject(object, options) {
+    var properties = Object.getOwnPropertyNames(object);
+    var symbols = Object.getOwnPropertySymbols ? Object.getOwnPropertySymbols(object) : [];
+
+    if (properties.length === 0 && symbols.length === 0) {
+      return '{}';
+    }
+
+    options.truncate -= 4;
+    options.seen = options.seen || [];
+
+    if (options.seen.indexOf(object) >= 0) {
+      return '[Circular]';
+    }
+
+    options.seen.push(object);
+    var propertyContents = inspectList(properties.map(function (key) {
+      return [key, object[key]];
+    }), options, inspectProperty);
+    var symbolContents = inspectList(symbols.map(function (key) {
+      return [key, object[key]];
+    }), options, inspectProperty);
+    options.seen.pop();
+    var sep = '';
+
+    if (propertyContents && symbolContents) {
+      sep = ', ';
+    }
+
+    return "{ ".concat(propertyContents).concat(sep).concat(symbolContents, " }");
+  }
+
+  var toStringTag = typeof Symbol !== 'undefined' && Symbol.toStringTag ? Symbol.toStringTag : false;
+  function inspectClass(value, options) {
+    var name = '';
+
+    if (toStringTag && toStringTag in value) {
+      name = value[toStringTag];
+    }
+
+    name = name || getFuncName_1(value.constructor); // Babel transforms anonymous classes to the name `_class`
+
+    if (!name || name === '_class') {
+      name = '<Anonymous Class>';
+    }
+
+    options.truncate -= name.length;
+    return "".concat(name).concat(inspectObject(value, options));
+  }
+
+  function inspectArguments(args, options) {
+    if (args.length === 0) return 'Arguments[]';
+    options.truncate -= 13;
+    return "Arguments[ ".concat(inspectList(args, options), " ]");
+  }
+
+  var errorKeys = ['stack', 'line', 'column', 'name', 'message', 'fileName', 'lineNumber', 'columnNumber', 'number', 'description'];
+  function inspectObject$1(error, options) {
+    var properties = Object.getOwnPropertyNames(error).filter(function (key) {
+      return errorKeys.indexOf(key) === -1;
+    });
+    var name = error.name;
+    options.truncate -= name.length;
+    var message = '';
+
+    if (typeof error.message === 'string') {
+      message = truncate(error.message, options.truncate);
+    } else {
+      properties.unshift('message');
+    }
+
+    message = message ? ": ".concat(message) : '';
+    options.truncate -= message.length + 5;
+    var propertyContents = inspectList(properties.map(function (key) {
+      return [key, error[key]];
+    }), options, inspectProperty);
+    return "".concat(name).concat(message).concat(propertyContents ? " { ".concat(propertyContents, " }") : '');
+  }
+
+  function inspectAttribute(_ref, options) {
+    var _ref2 = _slicedToArray(_ref, 2),
+        key = _ref2[0],
+        value = _ref2[1];
+
+    options.truncate -= 3;
+
+    if (!value) {
+      return "".concat(options.stylize(key, 'yellow'));
+    }
+
+    return "".concat(options.stylize(key, 'yellow'), "=").concat(options.stylize("\"".concat(value, "\""), 'string'));
+  }
+  function inspectHTMLCollection(collection, options) {
+    // eslint-disable-next-line no-use-before-define
+    return inspectList(collection, options, inspectHTML, '\n');
+  }
+  function inspectHTML(element, options) {
+    var properties = element.getAttributeNames();
+    var name = element.tagName.toLowerCase();
+    var head = options.stylize("<".concat(name), 'special');
+    var headClose = options.stylize(">", 'special');
+    var tail = options.stylize("</".concat(name, ">"), 'special');
+    options.truncate -= name.length * 2 + 5;
+    var propertyContents = '';
+
+    if (properties.length > 0) {
+      propertyContents += ' ';
+      propertyContents += inspectList(properties.map(function (key) {
+        return [key, element.getAttribute(key)];
+      }), options, inspectAttribute, ' ');
+    }
+
+    options.truncate -= propertyContents.length;
+    var truncate = options.truncate;
+    var children = inspectHTMLCollection(element.children, options);
+
+    if (children && children.length > truncate) {
+      children = "".concat(truncator, "(").concat(element.children.length, ")");
+    }
+
+    return "".concat(head).concat(propertyContents).concat(headClose).concat(children).concat(tail);
+  }
+
+  var symbolsSupported = typeof Symbol === 'function' && typeof Symbol.for === 'function';
+  var chaiInspect = symbolsSupported ? Symbol.for('chai/inspect') : '@@chai/inspect';
+  var nodeInspect = false;
+
+  try {
+    // eslint-disable-next-line global-require
+    var nodeUtil = require('util');
+
+    nodeInspect = nodeUtil.inspect ? nodeUtil.inspect.custom : false;
+  } catch (noNodeInspect) {
+    nodeInspect = false;
+  }
+
+  var constructorMap = new WeakMap();
+  var stringTagMap = {};
+  var baseTypesMap = {
+    undefined: function undefined$1(value, options) {
+      return options.stylize('undefined', 'undefined');
+    },
+    null: function _null(value, options) {
+      return options.stylize(null, 'null');
+    },
+    boolean: function boolean(value, options) {
+      return options.stylize(value, 'boolean');
+    },
+    Boolean: function Boolean(value, options) {
+      return options.stylize(value, 'boolean');
+    },
+    number: inspectNumber,
+    Number: inspectNumber,
+    bigint: inspectBigInt,
+    BigInt: inspectBigInt,
+    string: inspectString,
+    String: inspectString,
+    function: inspectFunction,
+    Function: inspectFunction,
+    symbol: inspectSymbol,
+    // A Symbol polyfill will return `Symbol` not `symbol` from typedetect
+    Symbol: inspectSymbol,
+    Array: inspectArray,
+    Date: inspectDate,
+    Map: inspectMap,
+    Set: inspectSet,
+    RegExp: inspectRegExp,
+    Promise: inspectPromise,
+    // WeakSet, WeakMap are totally opaque to us
+    WeakSet: function WeakSet(value, options) {
+      return options.stylize('WeakSet{…}', 'special');
+    },
+    WeakMap: function WeakMap(value, options) {
+      return options.stylize('WeakMap{…}', 'special');
+    },
+    Arguments: inspectArguments,
+    Int8Array: inspectTypedArray,
+    Uint8Array: inspectTypedArray,
+    Uint8ClampedArray: inspectTypedArray,
+    Int16Array: inspectTypedArray,
+    Uint16Array: inspectTypedArray,
+    Int32Array: inspectTypedArray,
+    Uint32Array: inspectTypedArray,
+    Float32Array: inspectTypedArray,
+    Float64Array: inspectTypedArray,
+    Generator: function Generator() {
+      return '';
+    },
+    DataView: function DataView() {
+      return '';
+    },
+    ArrayBuffer: function ArrayBuffer() {
+      return '';
+    },
+    Error: inspectObject$1,
+    HTMLCollection: inspectHTMLCollection,
+    NodeList: inspectHTMLCollection
+  }; // eslint-disable-next-line complexity
+
+  var inspectCustom = function inspectCustom(value, options, type) {
+    if (chaiInspect in value && typeof value[chaiInspect] === 'function') {
+      return value[chaiInspect](options);
+    }
+
+    if (nodeInspect && nodeInspect in value && typeof value[nodeInspect] === 'function') {
+      return value[nodeInspect](options.depth, options);
+    }
+
+    if ('inspect' in value && typeof value.inspect === 'function') {
+      return value.inspect(options.depth, options);
+    }
+
+    if ('constructor' in value && constructorMap.has(value.constructor)) {
+      return constructorMap.get(value.constructor)(value, options);
+    }
+
+    if (stringTagMap[type]) {
+      return stringTagMap[type](value, options);
+    }
+
+    return '';
+  };
+
+  var toString$1 = Object.prototype.toString; // eslint-disable-next-line complexity
+
+  function inspect(value, options) {
+    options = normaliseOptions(options);
+    options.inspect = inspect;
+    var _options = options,
+        customInspect = _options.customInspect;
+    var type = value === null ? 'null' : _typeof(value);
+
+    if (type === 'object') {
+      type = toString$1.call(value).slice(8, -1);
+    } // If it is a base value that we already support, then use Loupe's inspector
+
+
+    if (baseTypesMap[type]) {
+      return baseTypesMap[type](value, options);
+    } // If `options.customInspect` is set to true then try to use the custom inspector
+
+
+    if (customInspect && value) {
+      var output = inspectCustom(value, options, type);
+
+      if (output) {
+        if (typeof output === 'string') return output;
+        return inspect(output, options);
+      }
+    }
+
+    var proto = value ? Object.getPrototypeOf(value) : false; // If it's a plain Object then use Loupe's inspector
+
+    if (proto === Object.prototype || proto === null) {
+      return inspectObject(value, options);
+    } // Specifically account for HTMLElements
+    // eslint-disable-next-line no-undef
+
+
+    if (value && typeof HTMLElement === 'function' && value instanceof HTMLElement) {
+      return inspectHTML(value, options);
+    }
+
+    if ('constructor' in value) {
+      // If it is a class, inspect it like an object but add the constructor name
+      if (value.constructor !== Object) {
+        return inspectClass(value, options);
+      } // If it is an object with an anonymous prototype, display it as an object.
+
+
+      return inspectObject(value, options);
+    } // We have run out of options! Just stringify the value
+
+
+    return options.stylize(String(value), type);
+  }
+  function registerConstructor(constructor, inspector) {
+    if (constructorMap.has(constructor)) {
+      return false;
+    }
+
+    constructorMap.add(constructor, inspector);
+    return true;
+  }
+  function registerStringTag(stringTag, inspector) {
+    if (stringTag in stringTagMap) {
+      return false;
+    }
+
+    stringTagMap[stringTag] = inspector;
+    return true;
+  }
+  var custom = chaiInspect;
+
+  exports.custom = custom;
+  exports.default = inspect;
+  exports.inspect = inspect;
+  exports.registerConstructor = registerConstructor;
+  exports.registerStringTag = registerStringTag;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+})));
+
+},{"util":undefined}],38:[function(require,module,exports){
 
 /* !
  * Chai - pathval utility
@@ -10249,13 +10882,20 @@ function parsePath(path) {
   var str = path.replace(/([^\\])\[/g, '$1.[');
   var parts = str.match(/(\\\.|[^.]+?)+/g);
   return parts.map(function mapMatches(value) {
+    if (
+      value === 'constructor' ||
+      value === '__proto__' ||
+      value === 'prototype'
+    ) {
+      return {};
+    }
     var regexp = /^\[(\d+)\]$/;
     var mArr = regexp.exec(value);
     var parsed = null;
     if (mArr) {
       parsed = { i: parseFloat(mArr[1]) };
     } else {
-      parsed = { p: value.replace(/\\([.\[\]])/g, '$1') };
+      parsed = { p: value.replace(/\\([.[\]])/g, '$1') };
     }
 
     return parsed;
@@ -10280,7 +10920,7 @@ function parsePath(path) {
 function internalGetPathValue(obj, parsed, pathDepth) {
   var temporaryValue = obj;
   var res = null;
-  pathDepth = (typeof pathDepth === 'undefined' ? parsed.length : pathDepth);
+  pathDepth = typeof pathDepth === 'undefined' ? parsed.length : pathDepth;
 
   for (var i = 0; i < pathDepth; i++) {
     var part = parsed[i];
@@ -10291,7 +10931,7 @@ function internalGetPathValue(obj, parsed, pathDepth) {
         temporaryValue = temporaryValue[part.p];
       }
 
-      if (i === (pathDepth - 1)) {
+      if (i === pathDepth - 1) {
         res = temporaryValue;
       }
     }
@@ -10325,7 +10965,7 @@ function internalSetPathValue(obj, val, parsed) {
     part = parsed[i];
 
     // If it's the last part of the path, we set the 'propName' value with the property name
-    if (i === (pathDepth - 1)) {
+    if (i === pathDepth - 1) {
       propName = typeof part.p === 'undefined' ? part.i : part.p;
       // Now we set the property with the name held by 'propName' on object with the desired val
       tempObj[propName] = val;
@@ -10372,7 +11012,10 @@ function getPathInfo(obj, path) {
   var parsed = parsePath(path);
   var last = parsed[parsed.length - 1];
   var info = {
-    parent: parsed.length > 1 ? internalGetPathValue(obj, parsed, parsed.length - 1) : obj,
+    parent:
+      parsed.length > 1 ?
+        internalGetPathValue(obj, parsed, parsed.length - 1) :
+        obj,
     name: last.p || last.i,
     value: internalGetPathValue(obj, parsed),
   };
@@ -10463,10 +11106,10 @@ module.exports = {
   setPathValue: setPathValue,
 };
 
-},{}],38:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-	global.typeDetect = factory();
+	(global.typeDetect = factory());
 }(this, (function () {
 /* !
  * type-detect
@@ -10855,4 +11498,6 @@ return typeDetect;
 });
 });
 
-export default chai;
+var chai$1 = unwrapExports(chai);
+
+export { chai$1 as default };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,286 @@
 {
   "name": "@bundled-es-modules/chai",
-  "version": "4.2.0",
-  "lockfileVersion": 1,
+  "version": "4.3.7",
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "10.12.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
-      "dev": true
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "^1.0.1"
+  "packages": {
+    "": {
+      "name": "@bundled-es-modules/chai",
+      "version": "4.3.7",
+      "devDependencies": {
+        "chai": "4.3.7",
+        "rollup": "^3.10.1",
+        "rollup-plugin-commonjs": "^10.1.0"
       }
     },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+    "node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha1-X7LlNsGum/NTZu7Yeegn+lnKQcI=",
+      "dev": true,
+      "license": "MIT"
     },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha1-7GP23wGCkIjov1X8qDm81GSo7FE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha1-fHd1UTCS99+Y2N+Zlt0IXrZozG0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha1-rUyz44Y+gUUjyW8/WNJsxXD/AUQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha1-iy2sCzcfS8mU/eq6nrVC0DAC0Lc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha1-duSvSYEDxTLR7Mm+ECA2oh94e1M=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha1-3n+fr5HvihyR0CwuUxTIJ3283Rw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.10.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup/-/rollup-3.10.1.tgz",
+      "integrity": "sha1-VieJAe0R/CiYQh6OPiyBVbx7QLQ=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-commonjs": {
+      "version": "10.1.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+      "integrity": "sha1-QXrztUUDh44ITRJ6300cr4vrhvs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.12.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha1-X7LlNsGum/NTZu7Yeegn+lnKQcI=",
       "dev": true
     },
     "assertion-error": {
@@ -43,28 +289,18 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
-      }
-    },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.7",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha1-7GP23wGCkIjov1X8qDm81GSo7FE=",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -75,80 +311,32 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha1-fHd1UTCS99+Y2N+Zlt0IXrZozG0=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
     },
     "estree-walker": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
-      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
       "dev": true
     },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
       "dev": true,
-      "requires": {
-        "is-posix-bracket": "^0.1.0"
-      }
+      "optional": true
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      }
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^1.0.0"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
-    },
-    "fill-range": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-      "dev": true,
-      "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -156,300 +344,121 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^2.0.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-dotfile": {
+    "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "function-bind": "^1.1.1"
       }
     },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+    "is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha1-rUyz44Y+gUUjyW8/WNJsxXD/AUQ=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "has": "^1.0.3"
       }
     },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha1-iy2sCzcfS8mU/eq6nrVC0DAC0Lc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "@types/estree": "*"
       }
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha1-duSvSYEDxTLR7Mm+ECA2oh94e1M=",
       "dev": true,
       "requires": {
-        "isarray": "1.0.0"
-      }
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
+        "get-func-name": "^2.0.0"
       }
     },
     "magic-string": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+      "version": "0.25.9",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha1-3n+fr5HvihyR0CwuUxTIJ3283Rw=",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.1"
-      }
-    },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha1-hTTnenfOesWiUS6iHg/bj89sPY0=",
       "dev": true
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.22.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha1-J8suu1P5GrtJRwqSi7p1WAZqwXc=",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "rollup": {
-      "version": "0.64.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.64.1.tgz",
-      "integrity": "sha512-+ThdVXrvonJdOTzyybMBipP0uz605Z8AnzWVY3rf+cSGnLO7uNkJBlN+9jXqWOomkvumXfm/esmBpA5d53qm7g==",
+      "version": "3.10.1",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup/-/rollup-3.10.1.tgz",
+      "integrity": "sha1-VieJAe0R/CiYQh6OPiyBVbx7QLQ=",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.0.tgz",
-      "integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
+      "version": "10.1.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+      "integrity": "sha1-QXrztUUDh44ITRJ6300cr4vrhvs=",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.2",
-        "magic-string": "^0.25.1",
-        "resolve": "^1.8.1",
-        "rollup-pluginutils": "^2.3.3"
+        "estree-walker": "^0.6.1",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-pluginutils": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
-      "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
+      "version": "2.8.2",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.2",
-        "micromatch": "^2.3.11"
+        "estree-walker": "^0.6.1"
       }
     },
     "sourcemap-codec": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
-      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==",
+      "version": "1.4.8",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+      "dev": true
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "dev": true
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "resolved": "https://pkgs.dev.azure.com/INGCDaaS/IngOne/_packaging/central-npm-feed/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@bundled-es-modules/chai",
-  "version": "4.2.2",
+  "version": "4.3.7",
   "description": "mirror of chai, bundled and exposed as ES module (incl. typescript types)",
   "author": "Thomas Allmer <d4kmor@gmail.com>",
+  "type": "module",
   "main": "index.js",
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
-    "chai": "4.2.0",
-    "rollup": "^0.64.1",
-    "rollup-plugin-commonjs": "^9.1.5"
+    "chai": "4.3.7",
+    "rollup": "^3.10.1",
+    "rollup-plugin-commonjs": "^10.1.0"
   },
   "scripts": {
     "build": "rollup -c ./rollup.config.js"


### PR DESCRIPTION
Some build tools nowadays, like Vite to name one, have started complaining that modules are "definitely CJS" if they don't have `type: module` in `pkg.json`.

Bit annoying, but easy to fix I suppose so here's a PR :) took the liberty to update to latest while I was at it.